### PR TITLE
Update database config, manifest file, and README

### DIFF
--- a/.sandbox/manifest.yaml
+++ b/.sandbox/manifest.yaml
@@ -1,9 +1,8 @@
 hooks:
-  post-checkout:
-    cmd: 'bundle install'
   build:
-    cmd: './sandbox.sh'
-
+    cmd: |
+      ./sandbox.sh
+      bundle install
 daemons:
   app:
     run:

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ services:
   name: mysql
 - managed_service:
     properties:
-      database: superhero_test
+      database: superherotest
       password: batman
       username: brucewayne
     service_type: mysql

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,7 @@ development:
 test:
   <<: *default
   host: <%= ENV['MYSQLTEST_SERVICE_HOST'] %>
-  database: superhero_test
+  database: superherotest
 
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,15 +66,20 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
 
+  ## Database cleaner configuration options
+  DatabaseCleaner[:redis].db = "redis://#{ENV['REDIS_SERVICE_HOST']}:#{ENV['REDIS_SERVICE_PORT']}/0"
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:deletion)
   end
 
   config.before(:each) do
+    DatabaseCleaner[:redis].strategy = :deletion
     DatabaseCleaner.strategy = :deletion
   end
 
   config.before(:each, js: true) do
+    DatabaseCleaner[:redis].strategy = :deletion
     DatabaseCleaner.strategy = :truncation
   end
 


### PR DESCRIPTION
This PR contains some fixes for bugs found:

1. Test database connection issue was caused by ill-formed naming (using underscore `superhero_test` in name). Resolved by renaming db to `superherotest`. 
2. Creating sandbox fails PostCheckout (caused by gem dependency issue because `sandbox.sh` contains the dependency installation instructions but is run later in Build stage). Resolved by moving `bundle install` to Build after running `./sandbox.sh`.
3. Database cleaner for Rspec had error connecting to Redis. Resolved by setting proper envs and creating a valid db connection.
3. Updated README to reflect all changes