### PR TITLE
Permit tag_attributes with Strong Parameters

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -42,7 +42,7 @@ module Api
 
         # Define allowed parameters
         def application_params
-          params.require(:application).permit(:content, :status, :posting_id, :worker_id)
+          params.require(:application).permit(:content, :status, :posting_id, :worker_id, tag_attributes: [:content])
         end
 
         # Set the application whose id == params[:id]

--- a/app/controllers/api/v1/employers_controller.rb
+++ b/app/controllers/api/v1/employers_controller.rb
@@ -34,7 +34,8 @@ module Api
 
         # Define allowed parameters
         def employer_params
-          params.require(:employer).permit(:name, :email, :password, :password_confirmation, :location)
+          params.require(:employer).permit(:name, :email, :password, :password_confirmation, :location,
+                                           tag_attributes: [:content])
         end
 
         # Set the employer whose id == params[:id]

--- a/app/controllers/api/v1/postings_controller.rb
+++ b/app/controllers/api/v1/postings_controller.rb
@@ -43,7 +43,8 @@ module Api
 
         # Define allowed parameters
         def posting_params
-          params.require(:posting).permit(:title, :description, :employer_id, :hours, :status)
+          params.require(:posting).permit(:title, :description, :employer_id, :hours, :status,
+                                          tag_attributes: [:content])
         end
 
         # Set the posting whose id == params[:id]

--- a/app/controllers/api/v1/workers_controller.rb
+++ b/app/controllers/api/v1/workers_controller.rb
@@ -34,7 +34,8 @@ module Api
 
         # Define allowed parameters
         def worker_params
-          params.require(:worker).permit(:name, :email, :password, :password_confirmation, :hourly_rate)
+          params.require(:worker).permit(:name, :email, :password, :password_confirmation, :hourly_rate,
+                                         tag_attributes: [:content])
         end
 
         # Set the worker whose id == params[:id]

--- a/app/controllers/concerns/avatar_helper.rb
+++ b/app/controllers/concerns/avatar_helper.rb
@@ -6,7 +6,7 @@ module AvatarHelper
   class_methods do
     def avatar_url(email)
       gravatar_id = Digest::MD5.hexdigest(email)
-      "https://secure.gravatar.com/avatar/#{gravatar_id}"
+      "https://secure.gravatar.com/avatar/#{gravatar_id}?d=identicon"
     end
   end
 end


### PR DESCRIPTION
This PR does two things:

1. It adds `tag_attributes: [:content]` to the list of permitted parameters in each controller.
This will fix the error:
>  Unpermitted parameter: :tag_attributes

2. It updates all gravatar path urls to use geometric shapes as fallback avatar image `https://www.gravatar.com/avatar/XXX??d=identicon`.